### PR TITLE
Demonstrating caching of attributes and associations

### DIFF
--- a/app/controllers/api/v1/foos_controller.rb
+++ b/app/controllers/api/v1/foos_controller.rb
@@ -1,6 +1,9 @@
 module Api
   module V1
     class FoosController < ApiController
+      before_action :before_action
+      after_action :after_action
+
       def index
         @foos = [foo1, foo2]
         render json: @foos
@@ -20,6 +23,37 @@ module Api
         Foo.where(id: 2).first || Foo.create! do |f|
           f.id = 2
           f.bars << Bar.new
+        end
+      end
+
+      def before_action
+        case params[:cache]
+        when 'clear'.freeze then ActionController::Base.cache_store.clear
+        when 'on'.freeze    then self.perform_caching = true # NOTE: AMS caching is not changed by this
+        when 'off'.freeze   then self.perform_caching = false
+        else nil # no-op
+        end
+      end
+
+      def after_action
+        Rails.logger.debug do
+          {
+            ams_config: {
+              cache_store: ActiveModelSerializers.config.cache_store.present?,
+              perform_caching: ActiveModelSerializers.config.perform_caching
+            },
+            serializers_config: {
+              foo: Api::V1::FooSerializer._cache.present?,
+              bar: Api::V1::BarSerializer._cache.present?
+            },
+            controller_config: {
+              perform_caching: perform_caching
+            },
+            app_config: {
+              cache_store: Rails.configuration.cache_store.present?,
+              perform_caching: Rails.configuration.action_controller.perform_caching,
+            }
+          }.to_json
         end
       end
     end

--- a/app/models/bar.rb
+++ b/app/models/bar.rb
@@ -1,6 +1,8 @@
 class Bar < ActiveRecord::Base
   def batz
+    Rails.logger.info "Bar#batz[#{id}]: I'm going to sleep."
     sleep 1
+    Rails.logger.info "Bar#batz[#{id}]: I'm up. What did I miss?"
     'batz'
   end
 end

--- a/app/models/foo.rb
+++ b/app/models/foo.rb
@@ -1,3 +1,8 @@
 class Foo < ActiveRecord::Base
   has_many :bars
+
+  def id
+    Rails.logger.info "Foo#id[#{super}]: present!"
+    super
+  end
 end

--- a/app/serializers/api/v1/bar_serializer.rb
+++ b/app/serializers/api/v1/bar_serializer.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class BarSerializer < ActiveModel::Serializer
+      cache
       attributes :id, :batz
     end
   end

--- a/app/serializers/api/v1/foo_serializer.rb
+++ b/app/serializers/api/v1/foo_serializer.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class FooSerializer < ActiveModel::Serializer
+      cache
       attributes :id
       has_many :bars, serializer: BarSerializer
     end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,9 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
   config.action_controller.cache_store = :dalli_store
   config.consider_all_requests_local = false
+  # Configure logging
+  ActiveSupport::Cache::Store.logger = config.logger
+  config.log_level = :debug
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,6 +8,8 @@ Rails.application.configure do
   # Configure logging
   ActiveSupport::Cache::Store.logger = config.logger
   config.log_level = :debug
+  # otherwise deadlocks can occurr
+  config.middleware.delete 'Rack::Lock'
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,17 +1,10 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
-
-  # Do not eager load code on boot.
-  config.eager_load = false
-
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  # Set up production configuration
+  config.eager_load = true
+  config.cache_classes = true
+  config.action_controller.perform_caching = true
+  config.action_controller.cache_store = :dalli_store
+  config.consider_all_requests_local = false
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
It is perhaps surprising that a serializer only cached its attributes,
not its associations? (At least in this case)

Closes #1 